### PR TITLE
Update Ionide.ProjInfo.FCS, make use of `FCS.mapManyOptions` that caches project analysis.

### DIFF
--- a/Benchmarks.Generator.fsproj
+++ b/Benchmarks.Generator.fsproj
@@ -13,6 +13,7 @@
         <None Include="inputs/50_leaves.json" />
         <None Include="inputs/stress_big_dense.json" />
         <None Include="inputs/fantomas.json" />
+        <None Include="inputs/stress_huge_dense.json" />
         <None Include=".gitignore" />
         <None Include="README.md" />
     </ItemGroup>

--- a/Benchmarks.Generator.fsproj
+++ b/Benchmarks.Generator.fsproj
@@ -18,7 +18,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Ionide.ProjInfo.FCS" Version="0.59.1" Condition="$(ProjInfoProjectPath) == ''" />
+        <PackageReference Include="Ionide.ProjInfo.FCS" Version="0.59.2" Condition="$(ProjInfoProjectPath) == ''" />
         <ProjectReference Include="$(ProjInfoProjectPath)" Condition="$(ProjInfoProjectPath) != ''" />
     </ItemGroup>
     

--- a/Benchmarks.Runner/Benchmarks.Runner.fsproj
+++ b/Benchmarks.Runner/Benchmarks.Runner.fsproj
@@ -9,7 +9,10 @@
     </PropertyGroup>
 
     <PropertyGroup>
+        <!-- By default reference FCS via NuGet -->
         <FcsReferenceType Condition="'$(FcsReferenceType)' == ''">nuget</FcsReferenceType>
+        <!-- By default use the latest official release of FCS -->
+        <FcsReferenceType Condition="'$(FcsNugetVersion)' == ''">41.0.5</FcsReferenceType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -23,7 +26,7 @@
 
     <!-- Reference the FCS NuGet package with the specified $FcsVersion -->
     <ItemGroup Condition=" '$(FcsReferenceType)' == 'nuget' ">
-        <PackageReference Include="FSharp.Compiler.Service" Version="41.0.5" />
+        <PackageReference Include="FSharp.Compiler.Service" Version="$(FcsNugetVersion)" />
     </ItemGroup>
     <!-- Reference the dll specified in $FcsDllPath -->
     <ItemGroup Condition=" '$(FcsReferenceType)' == 'dll' ">

--- a/Benchmarks.Runner/Benchmarks.Runner.fsproj
+++ b/Benchmarks.Runner/Benchmarks.Runner.fsproj
@@ -12,7 +12,7 @@
         <!-- By default reference FCS via NuGet -->
         <FcsReferenceType Condition="'$(FcsReferenceType)' == ''">nuget</FcsReferenceType>
         <!-- By default use the latest official release of FCS -->
-        <FcsReferenceType Condition="'$(FcsNugetVersion)' == ''">41.0.5</FcsReferenceType>
+        <FcsNugetVersion Condition="'$(FcsNugetVersion)' == ''">41.0.5</FcsNugetVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -26,7 +26,7 @@
 
     <!-- Reference the FCS NuGet package with the specified $FcsVersion -->
     <ItemGroup Condition=" '$(FcsReferenceType)' == 'nuget' ">
-        <PackageReference Include="FSharp.Compiler.Service" Version="$(FcsNugetVersion)" />
+        <PackageReference Include="FSharp.Compiler.Service" Version="41.0.5" />
     </ItemGroup>
     <!-- Reference the dll specified in $FcsDllPath -->
     <ItemGroup Condition=" '$(FcsReferenceType)' == 'dll' ">

--- a/Benchmarks.Runner/Runner.fs
+++ b/Benchmarks.Runner/Runner.fs
@@ -9,10 +9,14 @@ open Benchmarks.Common.Dtos
 type FCSBenchmark (config : BenchmarkConfig) =
     let checker = FSharpChecker.Create(projectCacheSize = config.ProjectCacheSize)
         
-    let failOnErrors (results : FSharpCheckFileResults) =
-        printfn $"{results.Diagnostics.Length} diagnostics calculated:"
-        for d in results.Diagnostics do
-            printfn $"- {d.Message}"
+    let printDiagnostics (results : FSharpCheckFileResults) =
+        match results.Diagnostics with
+        | [||] ->
+            printfn $"No issues found in code to report."
+        | diagnostics ->
+            printfn $"{results.Diagnostics.Length} issues/diagnostics found:"
+            for d in results.Diagnostics do
+                printfn $"- {d.Message}"
     
     let performAction (action : BenchmarkAction) =
         let sw = Stopwatch.StartNew()
@@ -25,7 +29,7 @@ type FCSBenchmark (config : BenchmarkConfig) =
                 match answer with
                 | FSharpCheckFileAnswer.Aborted -> failwith "checker aborted"
                 | FSharpCheckFileAnswer.Succeeded results ->
-                    failOnErrors results
+                    printDiagnostics results
                 action, ((result, answer) :> Object)
         res
             

--- a/Generate.fs
+++ b/Generate.fs
@@ -242,6 +242,7 @@ module Generate =
         let makeDefault () =
             [
                 "FcsReferenceType", "nuget"
+                "FcsNugetVersion", "41.0.5"
             ]
         let makeDll (fcsDllPath : string) =
             [

--- a/Generate.fs
+++ b/Generate.fs
@@ -177,10 +177,14 @@ module Generate =
         if projects.Length = 0 then
             failwith $"No projects were loaded from {sln} - this indicates an error in cracking the projects"
         
-        let fsOptions =
-            projects
-            |> List.map (fun project -> Path.GetFileNameWithoutExtension(project.ProjectFileName), FCS.mapToFSharpProjectOptions project projects)
+        let fsOptions = FCS.mapManyOptions projects |> Seq.toList
+        
         fsOptions
+        |> List.zip projects
+        |> List.map (fun (project, fsOptions) ->
+            let name = Path.GetFileNameWithoutExtension(project.ProjectFileName)
+            name, fsOptions
+        )
         |> dict
     
     [<MethodImpl(MethodImplOptions.NoInlining)>]

--- a/Generate.fs
+++ b/Generate.fs
@@ -299,7 +299,7 @@ module Generate =
             FcsDllPath : string option
             [<CommandLine.Option('n', Default = 1, HelpText = "Number of iterations to run")>]
             Iterations : int
-            [<CommandLine.Option('v', Default = false, HelpText = "Verbose logging. Includes output of ")>]
+            [<CommandLine.Option('v', Default = false, HelpText = "Verbose logging. Includes output of all preparation steps.")>]
             Verbose : bool
         }
     

--- a/Generate.fs
+++ b/Generate.fs
@@ -249,7 +249,7 @@ module Generate =
                 "FcsDllPath", fcsDllPath 
             ]
     
-    let private prepareAndRun (config : Config) (case : BenchmarkCase) (doRun : bool) (cleanup : bool) =
+    let private prepareAndRun (config : Config) (case : BenchmarkCase) (dryRun : bool) (cleanup : bool) =
         let codebase = prepareCodebase config case
         let inputs = generateInputs case codebase.Path
         let inputsPath = makeInputsPath codebase.Path
@@ -258,7 +258,7 @@ module Generate =
         Directory.CreateDirectory(Path.GetDirectoryName(inputsPath)) |> ignore
         File.WriteAllText(inputsPath, serialized)
         
-        if doRun then
+        if dryRun = false then
             use _ = LogContext.PushProperty("step", "Run")
             let workingDir = "Benchmarks.Runner"
             let additionalEnvVariables =
@@ -290,8 +290,8 @@ module Generate =
             CheckoutsDir : string
             [<CommandLine.Option('i', Required = true, HelpText = "Path to the input file describing the benchmark")>]
             Input : string
-            [<CommandLine.Option(Default = true, HelpText = "If set to false, prepares the benchmark and prints the commandline to run it, then exits")>]
-            Run : bool
+            [<CommandLine.Option("dry-run", HelpText = "If set, prepares the benchmark and prints the commandline to run it, then exits")>]
+            DryRun : bool
             [<CommandLine.Option(Default = false, HelpText = "If set, removes the checkout directory afterwards. Doesn't apply to local codebases")>]
             Cleanup : bool
             [<CommandLine.Option('f', HelpText = "Path to the FSharp.Compiler.Service.dll to benchmark - by default a NuGet package is used instead")>]
@@ -345,7 +345,7 @@ module Generate =
                     reraise()
             
             use _ = LogContext.PushProperty("step", "PrepareAndRun")
-            prepareAndRun config case args.Run args.Cleanup
+            prepareAndRun config case args.DryRun args.Cleanup
         with ex ->
             if args.Verbose then
                 log.Fatal(ex, "Failure.")

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ graph TD;
     end
 ```
 ## How to use it
-### Run `Benchmark.Generator` to generate and run the benchmark
+### Run `Benchmark.Generator` to generate and run the benchmark using a locally-built FCS dll
 ```bash
-dotnet run -i inputs/50_leaves.json 
+dotnet run -i inputs/50_leaves.json -f Path/To/FSharp.Compiler.Service.dll 
 ```
 For more CLI options use `dotnet run --help`
 

--- a/inputs/stress_huge_dense.json
+++ b/inputs/stress_huge_dense.json
@@ -1,0 +1,20 @@
+﻿{
+  "Repo": {
+    "Name": "stress_big_dense",
+    "GitUrl": "https://github.com/dotnet/fsharp",
+    "Revision" : "a7b668136cc720e50b92b0cae0f06081c5df1117"
+  },
+  "CodebasePrep": [
+    {
+      "Command": "dotnet",
+      "Args": "restore tests/projects/stress/huge_netstandard/dense/Dense.sln"
+    }
+  ],
+  "SlnRelative": "tests/projects/stress/huge_netstandard/dense/Dense.sln",
+  "CheckActions": [
+    {
+      "FileName": "FSharpTest100.fs",
+      "ProjectName": "FSharpTest100"
+    }
+  ]
+}


### PR DESCRIPTION
This makes possible benchmarking big project analysis.

Now the 'big' and 'huge' samples from the dotnet/fsharp codebase can be tested.