### PR TITLE
Add build action

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fantomas": {
+      "version": "5.0.0-beta-009",
+      "commands": [
+        "fantomas"
+      ]
+    }
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+# Source https://github.com/G-Research/fsharp-formatting-conventions/blob/master/.editorconfig
+[*.fs]
+fsharp_space_before_uppercase_invocation=true
+fsharp_space_before_member=true
+fsharp_space_before_colon=true
+fsharp_space_before_semicolon=true
+fsharp_multiline_block_brackets_on_same_column=true
+fsharp_newline_between_type_definition_and_members=true
+fsharp_align_function_signature_to_indentation=true
+fsharp_alternative_long_member_definitions=true
+fsharp_multi_line_lambda_closing_newline=true
+fsharp_experimental_keep_indent_in_branch=true
+fsharp_bar_before_discriminated_union_declaration=true

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Initial format
+b1c1ebd2dd454425b7b10e3f46c9441f6dcf36e4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,6 +19,10 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x
+    - name: Restore tools
+      run: dotnet tool restore
+    - name: Check formatting
+      run: dotnet fantomas . -r --check
     - name: Restore dependencies
       run: dotnet restore ./FCSBenchmark.sln
     - name: Build

--- a/FCSCheckouts.fs
+++ b/FCSCheckouts.fs
@@ -7,16 +7,9 @@ open FCSBenchmark.Generator.RepoSetup
 open LibGit2Sharp
 open Serilog.Events
 
-type FCSGeneralRepoSpec =
-    {
-        GitUrl : string
-        Revision : string
-    }
-    
-type FCSMainRepoSpec =
-    {
-        Revision : string
-    }
+type FCSGeneralRepoSpec = { GitUrl : string ; Revision : string }
+
+type FCSMainRepoSpec = { Revision : string }
 
 type FCSRepoSpec =
     | Main of FCSMainRepoSpec
@@ -25,11 +18,7 @@ type FCSRepoSpec =
 module FCSRepoSpec =
     let toFullSpec (options : FCSRepoSpec) =
         match options with
-        | FCSRepoSpec.Main {Revision = revision} ->
-            {
-                GitUrl = ""
-                Revision = revision
-            }
+        | FCSRepoSpec.Main { Revision = revision } -> { GitUrl = "" ; Revision = revision }
         | FCSRepoSpec.Custom spec -> spec
         |> function
             | spec ->
@@ -40,32 +29,40 @@ module FCSRepoSpec =
                 }
 
 let private fcsDllPath (checkoutDir : string) =
-    Path.Combine(checkoutDir, "artifacts/bin/FSharp.Compiler.Service/Release/netstandard2.0/FSharp.Compiler.Service.dll")
-    
-let checkoutContainsBuiltFcs (checkoutDir : string) =
-    File.Exists(fcsDllPath checkoutDir)
+    Path.Combine (
+        checkoutDir,
+        "artifacts/bin/FSharp.Compiler.Service/Release/netstandard2.0/FSharp.Compiler.Service.dll"
+    )
+
+let checkoutContainsBuiltFcs (checkoutDir : string) = File.Exists (fcsDllPath checkoutDir)
 
 let buildAndPackFCS (repoRootDir : string) (forceFCSBuild : bool) : unit =
-    let packagesDir = Path.Combine(repoRootDir, "artifacts", "packages", "Release", "Release")
+    let packagesDir =
+        Path.Combine (repoRootDir, "artifacts", "packages", "Release", "Release")
+
     let packagesExist =
-        if Directory.Exists(packagesDir) then
-            match Directory.EnumerateFiles(packagesDir, "FSharp.Compiler.Service.*.nupkg") |> Seq.toList with
+        if Directory.Exists (packagesDir) then
+            match
+                Directory.EnumerateFiles (packagesDir, "FSharp.Compiler.Service.*.nupkg")
+                |> Seq.toList
+            with
             | [] -> false
             | _ -> true
         else
-            log.Information($"PackagesDir {packagesDir} DOES NOT exist")
+            log.Information ($"PackagesDir {packagesDir} DOES NOT exist")
             false
+
     let build () =
-        log.Information("Building and packing FCS in {repo}.", repoRootDir)
+        log.Information ("Building and packing FCS in {repo}.", repoRootDir)
         Utils.runProcess "cmd" $"/C build.cmd -c Release -pack -noVisualStudio" repoRootDir [] LogEventLevel.Verbose
+
     match packagesExist, forceFCSBuild with
     | false, _ ->
-        log.Information($"packages don't exist - building")
+        log.Information ($"packages don't exist - building")
         build ()
-    | true, false ->
-        log.Information("FCS nupkg file exists in {repo} codebase - not building again.", repoRootDir)
+    | true, false -> log.Information ("FCS nupkg file exists in {repo} codebase - not building again.", repoRootDir)
     | true, true ->
-        log.Information("FCS nupkg file exists in {repo} codebase, but forceFCSBuild was set.", repoRootDir)
+        log.Information ("FCS nupkg file exists in {repo} codebase, but forceFCSBuild was set.", repoRootDir)
         build ()
 
 type FCSCheckout =
@@ -73,41 +70,38 @@ type FCSCheckout =
         Spec : FCSRepoSpec
         Repo : Repository
     }
-    with
-        member this.FullSpec = this.Spec |> FCSRepoSpec.toFullSpec
-        member this.Dir = this.Repo.Info.WorkingDirectory
-        member this.PackDir = this.Dir // Root dir can be provided to the runner instead of the packages directory
-        
+
+    member this.FullSpec = this.Spec |> FCSRepoSpec.toFullSpec
+    member this.Dir = this.Repo.Info.WorkingDirectory
+    member this.PackDir = this.Dir // Root dir can be provided to the runner instead of the packages directory
+
 let checkoutAndBuild (config : Config) (fcsSpec : FCSRepoSpec) : FCSCheckout =
     let spec = FCSRepoSpec.toFullSpec fcsSpec
     let repo = prepareRepo config spec
     buildAndPackFCS repo.Info.WorkingDirectory config.ForceFCSBuild
-    {
-        Spec = fcsSpec
-        Repo = repo
-    }
-    
-type NuGetVersion = NuGetVersion of string
+    { Spec = fcsSpec ; Repo = repo }
+
+type NuGetVersion = | NuGetVersion of string
 
 [<RequireQualifiedAccess>]
 type FCSVersion =
     | OfficialNuGet of NuGetVersion
     | Local of DirectoryInfo // Root directory or package directory
     | Git of FCSRepoSpec
-    
+
 [<RequireQualifiedAccess>]
 type NuGetFCSVersion =
     | Official of version : string
     | Local of sourceDir : string
-    
+
 let prepareFCSVersions (config : Config) (versions : FCSVersion list) : NuGetFCSVersion list =
     versions
     |> List.map (
         function
-            | FCSVersion.OfficialNuGet (NuGetVersion version) -> NuGetFCSVersion.Official version
-            | FCSVersion.Local root -> NuGetFCSVersion.Local root.FullName
-            | FCSVersion.Git spec ->
-                let checkout = checkoutAndBuild config spec
-                NuGetFCSVersion.Local checkout.Dir
-            
+        | FCSVersion.OfficialNuGet (NuGetVersion version) -> NuGetFCSVersion.Official version
+        | FCSVersion.Local root -> NuGetFCSVersion.Local root.FullName
+        | FCSVersion.Git spec ->
+            let checkout = checkoutAndBuild config spec
+            NuGetFCSVersion.Local checkout.Dir
+
     )

--- a/Generate.fs
+++ b/Generate.fs
@@ -18,9 +18,17 @@ open Serilog
 open Serilog.Context
 open Serilog.Events
 
+[<Literal>]
+let Analyze = "analyze"
+
+[<Literal>]
+let Build = "build"
+
 [<CLIMutable>]
 type CheckAction =
     {
+        /// Can be "analyze" or "build"
+        Type : string
         FileName : string
         ProjectName : string
         [<JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)>]
@@ -123,6 +131,9 @@ let private loadOptions (sln : string) =
     let toolsPath = init sln
     doLoadOptions toolsPath sln
 
+let private projectOptionsToCommandLineArguments (options : FSharpProjectOptions) : string array =
+    [| yield! options.OtherOptions ; yield! options.SourceFiles |]
+
 let private generateInputs (case : BenchmarkCase) (codeRoot : string) =
     let sln = Path.Combine (codeRoot, case.SlnRelative)
     let options = loadOptions sln
@@ -131,26 +142,33 @@ let private generateInputs (case : BenchmarkCase) (codeRoot : string) =
 
     let actions =
         case.CheckActions
-        |> List.mapi (fun i {
-                                FileName = projectRelativeFileName
-                                ProjectName = projectName
-                                Repeat = repeat
-                            } ->
-            let project = options[projectName]
+        |> List.mapi (fun i checkAction ->
+            let project = options[checkAction.ProjectName]
 
             let filePath =
-                Path.Combine (Path.GetDirectoryName (project.ProjectFileName), projectRelativeFileName)
+                Path.Combine (Path.GetDirectoryName project.ProjectFileName, checkAction.FileName)
 
             let fileText = File.ReadAllText (filePath)
 
-            BenchmarkAction.AnalyseFile
-                {
-                    FileName = filePath
-                    FileVersion = i
-                    SourceText = fileText
-                    Options = project
-                    Repeat = repeat
-                }
+            match checkAction.Type with
+            | Analyze ->
+                BenchmarkAction.AnalyseFile
+                    {
+                        FileName = filePath
+                        FileVersion = i
+                        SourceText = fileText
+                        Options = project
+                        Repeat = checkAction.Repeat
+                    }
+            | Build ->
+                BenchmarkAction.BuildProject
+                    {
+                        Args = projectOptionsToCommandLineArguments project
+                        ProjectFileName = project.ProjectFileName
+                        Repeat = checkAction.Repeat
+                    }
+            | unknownType ->
+                failwith $"Unrecognized Action Type {unknownType}, supported values are \"{Analyze}\" and \"{Build}\""
         )
 
     let config : BenchmarkConfig =

--- a/Generate.fs
+++ b/Generate.fs
@@ -17,7 +17,7 @@ open Newtonsoft.Json.Linq
 open Serilog
 open Serilog.Context
 open Serilog.Events
-    
+
 [<CLIMutable>]
 type CheckAction =
     {
@@ -29,11 +29,7 @@ type CheckAction =
     }
 
 [<CLIMutable>]
-type CodebasePrepStep =
-    {
-        Command : string
-        Args : string
-    }
+type CodebasePrepStep = { Command : string ; Args : string }
 
 [<CLIMutable>]
 type BenchmarkCase =
@@ -44,110 +40,133 @@ type BenchmarkCase =
         SlnRelative : string
         CheckActions : CheckAction list
     }
-    
+
 [<MethodImpl(MethodImplOptions.NoInlining)>]
 let init (slnPath : string) =
     let directoryName = Path.GetDirectoryName slnPath
-    log.Verbose("Calling {method} for directory {directory}", "Ionide.ProjInfo.Init.init", directoryName)
-    Init.init (DirectoryInfo(directoryName)) None
+    log.Verbose ("Calling {method} for directory {directory}", "Ionide.ProjInfo.Init.init", directoryName)
+    Init.init (DirectoryInfo (directoryName)) None
 
 type Codebase =
     | Local of string
     | Git of LibGit2Sharp.Repository
-    with member this.Path = match this with | Local codeRoot -> codeRoot | Git repo -> repo.Info.WorkingDirectory
+
+    member this.Path =
+        match this with
+        | Local codeRoot -> codeRoot
+        | Git repo -> repo.Info.WorkingDirectory
 
 let prepareCodebase (config : Config) (case : BenchmarkCase) : Codebase =
-    use _ = LogContext.PushProperty("step", "PrepareCodebase")
+    use _ = LogContext.PushProperty ("step", "PrepareCodebase")
+
     let codebase =
         match (case.Repo :> obj, case.LocalCodeRoot) with
         | null, null -> failwith "Either git repo or local code root details are required"
         | _, null ->
             let repo = prepareRepo config case.Repo
             Codebase.Git repo
-        | null, codeRoot ->
-            Codebase.Local codeRoot
+        | null, codeRoot -> Codebase.Local codeRoot
         | _, _ -> failwith $"Both git repo and local code root were provided - that's not supported"
-    
-    log.Information("Running {steps} codebase prep steps", case.CodebasePrep.Length)
+
+    log.Information ("Running {steps} codebase prep steps", case.CodebasePrep.Length)
+
     case.CodebasePrep
     |> List.iteri (fun i step ->
-        log.Verbose("Running codebase prep step {step}/{steps}", i+1, case.CodebasePrep.Length)
+        log.Verbose ("Running codebase prep step {step}/{steps}", i + 1, case.CodebasePrep.Length)
         Utils.runProcess step.Command step.Args codebase.Path [] LogEventLevel.Verbose
     )
+
     codebase
 
 let private withRedirectedConsole<'a> (f : unit -> 'a) =
     let originalOut = Console.Out
     let originalError = Console.Error
-    use out = new StringWriter()
-    use error = new StringWriter()
-    Console.SetOut(out)
-    Console.SetError(error)
-    let res = f()
-    Console.SetOut(originalOut)
-    Console.SetOut(originalError)
-    res, (out.ToString(), error.ToString())
+    use out = new StringWriter ()
+    use error = new StringWriter ()
+    Console.SetOut (out)
+    Console.SetError (error)
+    let res = f ()
+    Console.SetOut (originalOut)
+    Console.SetOut (originalError)
+    res, (out.ToString (), error.ToString ())
 
 [<MethodImpl(MethodImplOptions.NoInlining)>]
 let private doLoadOptions (toolsPath : ToolsPath) (sln : string) =
     // TODO allow customization of build properties
     let props = []
-    let loader = WorkspaceLoader.Create(toolsPath, props)
-    let _ = Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults()
-    
+    let loader = WorkspaceLoader.Create (toolsPath, props)
+    let _ = Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults ()
+
     let projects, _ =
-        fun () -> loader.LoadSln(sln, [], BinaryLogGeneration.Off) |> Seq.toList
+        fun () -> loader.LoadSln (sln, [], BinaryLogGeneration.Off) |> Seq.toList
         |> withRedirectedConsole
-        
-    log.Information("{projectsCount} projects loaded from {sln}", projects.Length, sln)
+
+    log.Information ("{projectsCount} projects loaded from {sln}", projects.Length, sln)
+
     if projects.Length = 0 then
         failwith $"No projects were loaded from {sln} - this indicates an error in cracking the projects"
-    
+
     let fsOptions = FCS.mapManyOptions projects |> Seq.toList
-    
+
     fsOptions
     |> List.zip projects
     |> List.map (fun (project, fsOptions) ->
-        let name = Path.GetFileNameWithoutExtension(project.ProjectFileName)
+        let name = Path.GetFileNameWithoutExtension (project.ProjectFileName)
         name, fsOptions
     )
     |> dict
 
 [<MethodImpl(MethodImplOptions.NoInlining)>]
 let private loadOptions (sln : string) =
-    use _ = LogContext.PushProperty("step", "LoadOptions")
-    log.Verbose("Constructing FSharpProjectOptions from {sln}", sln)
+    use _ = LogContext.PushProperty ("step", "LoadOptions")
+    log.Verbose ("Constructing FSharpProjectOptions from {sln}", sln)
     let toolsPath = init sln
     doLoadOptions toolsPath sln
 
 let private generateInputs (case : BenchmarkCase) (codeRoot : string) =
-    let sln = Path.Combine(codeRoot, case.SlnRelative)
+    let sln = Path.Combine (codeRoot, case.SlnRelative)
     let options = loadOptions sln
-    
-    log.Verbose("Generating actions")
+
+    log.Verbose ("Generating actions")
+
     let actions =
         case.CheckActions
-        |> List.mapi (fun i {FileName = projectRelativeFileName; ProjectName = projectName; Repeat = repeat} ->
+        |> List.mapi (fun i {
+                                FileName = projectRelativeFileName
+                                ProjectName = projectName
+                                Repeat = repeat
+                            } ->
             let project = options[projectName]
-            let filePath = Path.Combine(Path.GetDirectoryName(project.ProjectFileName), projectRelativeFileName)
-            let fileText = File.ReadAllText(filePath)
-            BenchmarkAction.AnalyseFile {FileName = filePath; FileVersion = i; SourceText = fileText; Options = project; Repeat = repeat}
+
+            let filePath =
+                Path.Combine (Path.GetDirectoryName (project.ProjectFileName), projectRelativeFileName)
+
+            let fileText = File.ReadAllText (filePath)
+
+            BenchmarkAction.AnalyseFile
+                {
+                    FileName = filePath
+                    FileVersion = i
+                    SourceText = fileText
+                    Options = project
+                    Repeat = repeat
+                }
         )
-    
+
     let config : BenchmarkConfig =
         {
             BenchmarkConfig.ProjectCacheSize = 200
         }
-        
+
     {
         BenchmarkInputs.Actions = actions
         BenchmarkInputs.Config = config
     }
 
 let private makeInputsPath (codeRoot : string) =
-    let artifactsDir = Path.Combine(codeRoot, ".artifacts")
-    let dateStr = DateTime.UtcNow.ToString("yyyy-MM-dd_HH-mm-ss")
-    Path.Combine(artifactsDir, $"{dateStr}.fcsinputs.json") 
+    let artifactsDir = Path.Combine (codeRoot, ".artifacts")
+    let dateStr = DateTime.UtcNow.ToString ("yyyy-MM-dd_HH-mm-ss")
+    Path.Combine (artifactsDir, $"{dateStr}.fcsinputs.json")
 
 // These are the env variables that Ionide.ProjInfo seems to set (in-process).
 // We need to get rid of them so that the child 'dotnet run' process is using the right tools
@@ -161,11 +180,10 @@ let private projInfoEnvVariables =
     ]
 
 let private emptyProjInfoEnvironmentVariables () =
-    projInfoEnvVariables
-    |> List.map (fun var -> var, "")
-    
+    projInfoEnvVariables |> List.map (fun var -> var, "")
+
 let private resultsJsonPath (bdnArtifactDir : string) (benchmarkName : string) =
-    Path.Combine(bdnArtifactDir, $@"results/{benchmarkName}-report.json")
+    Path.Combine (bdnArtifactDir, $@"results/{benchmarkName}-report.json")
 
 type RunResultSummary =
     {
@@ -176,68 +194,76 @@ type RunResultSummary =
 let extractResultsFromJson (summary : JObject) : RunResultSummary =
     let benchmark = summary["Benchmarks"][0]
     let stats = benchmark["Statistics"]
-    let meanMicros = stats["Mean"].ToString() |> Double.Parse
-    
+    let meanMicros = stats[ "Mean" ].ToString () |> Double.Parse
+
     let metrics = benchmark["Metrics"] :?> JArray
+
     let allocatedBytes =
         let found =
             metrics
-            |> Seq.find (fun m -> (m["Descriptor"]["Id"]).ToString() = "Allocated Memory")
-        found["Value"].ToString() |> Double.Parse
-        
-    { MeanS = Math.Round(meanMicros / 1000000000.0, 3); AllocatedMB = Math.Round(allocatedBytes / 1024.0 / 1024.0, 3) }
-    
+            |> Seq.find (fun m -> (m["Descriptor"]["Id"]).ToString () = "Allocated Memory")
+
+        found[ "Value" ].ToString () |> Double.Parse
+
+    {
+        MeanS = Math.Round (meanMicros / 1000000000.0, 3)
+        AllocatedMB = Math.Round (allocatedBytes / 1024.0 / 1024.0, 3)
+    }
+
 let private readBasicJsonResults (bdnArtifactsDir : string) (benchmarkClass : string) =
-    let json = File.ReadAllText(resultsJsonPath bdnArtifactsDir benchmarkClass)
-    let jObject = JsonConvert.DeserializeObject<JObject>(json)
+    let json = File.ReadAllText (resultsJsonPath bdnArtifactsDir benchmarkClass)
+    let jObject = JsonConvert.DeserializeObject<JObject> (json)
     extractResultsFromJson jObject
 
 let private readJsonResultsSummary (bdnArtifactsDir : string) (benchmarkClass : string) =
     let jsonResultsPath = resultsJsonPath bdnArtifactsDir benchmarkClass
-    let json = File.ReadAllText(jsonResultsPath)
-    let jObject = JsonConvert.DeserializeObject<JObject>(json)
+    let json = File.ReadAllText (jsonResultsPath)
+    let jObject = JsonConvert.DeserializeObject<JObject> (json)
     extractResultsFromJson jObject
 
 let copyDir sourceDir targetDir =
-    Directory.CreateDirectory(targetDir) |> ignore
-    Directory.EnumerateFiles(sourceDir)
-    |> Seq.iter (fun sourceFile ->
-        File.Copy(sourceFile, Path.Combine(targetDir, Path.GetFileName(sourceFile)))
-    )
+    Directory.CreateDirectory (targetDir) |> ignore
+
+    Directory.EnumerateFiles (sourceDir)
+    |> Seq.iter (fun sourceFile -> File.Copy (sourceFile, Path.Combine (targetDir, Path.GetFileName (sourceFile))))
 
 let rec copyRunnerProjectFilesToTemp (sourceDir : string) =
     let buildDir =
-        let file = Path.GetTempFileName()
-        File.Delete(file)
-        Path.Combine(Path.GetDirectoryName(file), Path.GetFileNameWithoutExtension(file))
+        let file = Path.GetTempFileName ()
+        File.Delete (file)
+        Path.Combine (Path.GetDirectoryName (file), Path.GetFileNameWithoutExtension (file))
+
     try
-        Directory.CreateDirectory(buildDir) |> ignore
-        for dirName in ["Runner"; "Serialisation"] do
-            let sourceDir = Path.Combine(sourceDir, dirName)
-            let targetDir = Path.Combine(buildDir, dirName)
-            Directory.CreateDirectory(targetDir) |> ignore
-            Directory.EnumerateFiles(sourceDir)
+        Directory.CreateDirectory (buildDir) |> ignore
+
+        for dirName in [ "Runner" ; "Serialisation" ] do
+            let sourceDir = Path.Combine (sourceDir, dirName)
+            let targetDir = Path.Combine (buildDir, dirName)
+            Directory.CreateDirectory (targetDir) |> ignore
+
+            Directory.EnumerateFiles (sourceDir)
             |> Seq.iter (fun sourceFile ->
-                File.Copy(sourceFile, Path.Combine(targetDir, Path.GetFileName(sourceFile)))
+                File.Copy (sourceFile, Path.Combine (targetDir, Path.GetFileName (sourceFile)))
             )
-        Path.Combine(buildDir, "Runner")
+
+        Path.Combine (buildDir, "Runner")
     with _ ->
-        Directory.Delete(buildDir, recursive = true)
-        reraise()
+        Directory.Delete (buildDir, recursive = true)
+        reraise ()
 
 type DisposableTempDir() =
-    let path = Path.GetTempFileName()
-    do
-        File.Delete(path)
-    let dir = Directory.CreateDirectory(path)
-    
+    let path = Path.GetTempFileName ()
+    do File.Delete (path)
+    let dir = Directory.CreateDirectory (path)
+
     interface IDisposable with
-        member _.Dispose() =
+        member _.Dispose () =
             if dir.Exists then
                 try
-                    dir.Delete()
-                with e -> log.Warning("Failed to delete temp directory {dir}.", dir.FullName)
-    
+                    dir.Delete ()
+                with e ->
+                    log.Warning ("Failed to delete temp directory {dir}.", dir.FullName)
+
     member this.Dir = dir
 
 let private prepareAndRun
@@ -255,209 +281,318 @@ let private prepareAndRun
     let codebase = prepareCodebase config case
     let inputs = generateInputs case codebase.Path
     let inputsPath = makeInputsPath codebase.Path
-    log.Information("Serializing inputs as {inputsPath}", inputsPath)        
+    log.Information ("Serializing inputs as {inputsPath}", inputsPath)
     let serialized = serializeInputs inputs
-    Directory.CreateDirectory(Path.GetDirectoryName(inputsPath)) |> ignore
-    File.WriteAllText(inputsPath, serialized)
-    
+    Directory.CreateDirectory (Path.GetDirectoryName (inputsPath)) |> ignore
+    File.WriteAllText (inputsPath, serialized)
+
     if dryRun = false then
-        use _ = LogContext.PushProperty("step", "Run")
-        let workingDir = Path.GetDirectoryName(Assembly.GetAssembly(typeof<RepoSpec>).Location)
+        use _ = LogContext.PushProperty ("step", "Run")
+
+        let workingDir =
+            Path.GetDirectoryName (Assembly.GetAssembly(typeof<RepoSpec>).Location)
+
         let workingDir = copyRunnerProjectFilesToTemp workingDir
-        use nugetPackagesDir = new DisposableTempDir()
+        use nugetPackagesDir = new DisposableTempDir ()
+
         let extraEnvVariables =
             [
                 "DOTNET_ROOT_X64", ""
-                // Avoid caching NuGet packages by the benchmark by using a temp directory.
-                // Otherwise newer versions of locally-built FCS might be shadowed by older versions
-                // "NUGET_PACKAGES", nugetPackagesDir.Dir.FullName
+            // Avoid caching NuGet packages by the benchmark by using a temp directory.
+            // Otherwise newer versions of locally-built FCS might be shadowed by older versions
+            // "NUGET_PACKAGES", nugetPackagesDir.Dir.FullName
             ]
-        let envVariables = emptyProjInfoEnvironmentVariables() @ extraEnvVariables
-        let bdnArtifactsDir = Path.Combine(Environment.CurrentDirectory, "BenchmarkDotNet.Artifacts")
+
+        let envVariables = emptyProjInfoEnvironmentVariables () @ extraEnvVariables
+
+        let bdnArtifactsDir =
+            Path.Combine (Environment.CurrentDirectory, "BenchmarkDotNet.Artifacts")
+
         let exe = "dotnet"
+
         let versionsArgs =
             let o =
                 versions
-                |> List.choose (function NuGetFCSVersion.Official v -> Some v | _ -> None)
+                |> List.choose (
+                    function
+                    | NuGetFCSVersion.Official v -> Some v
+                    | _ -> None
+                )
                 |> function
-                | [] -> ""
-                | officials -> "--official " + String.Join(" ", officials)
+                    | [] -> ""
+                    | officials -> "--official " + String.Join (" ", officials)
+
             let l =
                 versions
-                |> List.choose (function NuGetFCSVersion.Local v -> Some v | _ -> None)
+                |> List.choose (
+                    function
+                    | NuGetFCSVersion.Local v -> Some v
+                    | _ -> None
+                )
                 |> function
-                | [] -> ""
-                | locals ->
-                    "--local " + String.Join(" ", locals |> List.map (fun local -> local.TrimEnd([|'\\'; '/'|])))
+                    | [] -> ""
+                    | locals ->
+                        "--local "
+                        + String.Join (" ", locals |> List.map (fun local -> local.TrimEnd ([| '\\' ; '/' |])))
+
             o + " " + l
+
         let otelStr = if recordOtelJaeger then "--record-otel-jaeger" else ""
         let parallelAnalysisStr = $"--parallel-analysis={parallelAnalysisMode}"
         let gcModeStr = $"--gc={gcMode}"
-        let artifactsPath = Path.Combine(Environment.CurrentDirectory, "FCSBenchmark.Artifacts")
-        let args = $"run -c Release -- --artifacts-path={artifactsPath} --input={inputsPath} --iterations={iterations} --warmups={warmups} {otelStr} {parallelAnalysisStr} {gcModeStr} {versionsArgs}".Trim()
+
+        let artifactsPath =
+            Path.Combine (Environment.CurrentDirectory, "FCSBenchmark.Artifacts")
+
+        let args =
+            $"run -c Release -- --artifacts-path={artifactsPath} --input={inputsPath} --iterations={iterations} --warmups={warmups} {otelStr} {parallelAnalysisStr} {gcModeStr} {versionsArgs}"
+                .Trim ()
+
         let env =
             envVariables
-            |> List.filter (fun (key, value) -> String.IsNullOrEmpty(value) = false)
+            |> List.filter (fun (key, value) -> String.IsNullOrEmpty (value) = false)
             |> List.map (fun (key, value) -> $"{key}={value}")
-            |> fun x -> String.Join(" ", x)
-        log.Information(
+            |> fun x -> String.Join (" ", x)
+
+        log.Information (
             "Starting the benchmark:\n\
              - Full BDN output can be found in {artifactFiles}.\n\
              - Full commandline: '{exe} {args}'\n\
-             - Working directory: '{dir}'.", $"{bdnArtifactsDir}/*.log\n\
-             - Extra environment variables: {env}"
-             , exe, args, workingDir)
+             - Working directory: '{dir}'.",
+            $"{bdnArtifactsDir}/*.log\n\
+             - Extra environment variables: {env}",
+            exe,
+            args,
+            workingDir
+        )
+
         Utils.runProcess exe args workingDir envVariables LogEventLevel.Information
     else
-        log.Information("Not running the benchmark as requested")
-        
+        log.Information ("Not running the benchmark as requested")
+
     match codebase, cleanup with
     | Local _, _ -> ()
     | Git _, false -> ()
     | Git repo, true ->
-        log.Information("Cleaning up checked out git repo {repoPath} as requested", repo.Info.Path)
+        log.Information ("Cleaning up checked out git repo {repoPath} as requested", repo.Info.Path)
         Directory.Delete repo.Info.Path
 
 type Args =
     {
         [<CommandLine.Option('c', "checkouts", Default = ".artifacts", HelpText = "Base directory for git checkouts")>]
         CheckoutsDir : string
-        [<CommandLine.Option("forceFcsBuild", Default = false, HelpText = "Force build git-sourced FCS versions even if the binaries already exist")>]
+        [<CommandLine.Option("forceFcsBuild",
+                             Default = false,
+                             HelpText = "Force build git-sourced FCS versions even if the binaries already exist")>]
         ForceFCSBuild : bool
         [<CommandLine.Option('i', SetName = "input", HelpText = "Path to the input file describing the benchmark.")>]
         Input : string
-        [<CommandLine.Option("sample", SetName = "input", HelpText = "Use a predefined sample benchmark with the given name")>]
+        [<CommandLine.Option("sample",
+                             SetName = "input",
+                             HelpText = "Use a predefined sample benchmark with the given name")>]
         SampleInput : string
-        [<CommandLine.Option("dry-run", HelpText = "If set, prepares the benchmark and prints the commandline to run it, then exits")>]
+        [<CommandLine.Option("dry-run",
+                             HelpText =
+                                 "If set, prepares the benchmark and prints the commandline to run it, then exits")>]
         DryRun : bool
-        [<CommandLine.Option(Default = false, HelpText = "If set, removes the checkout directory afterwards. Doesn't apply to local codebases")>]
+        [<CommandLine.Option(Default = false,
+                             HelpText =
+                                 "If set, removes the checkout directory afterwards. Doesn't apply to local codebases")>]
         Cleanup : bool
         [<CommandLine.Option('n', "iterations", Default = 1, HelpText = "Number of iterations to run")>]
         Iterations : int
         [<CommandLine.Option('w', "warmups", Default = 1, HelpText = "Number of warmups to run")>]
         Warmups : int
-        [<CommandLine.Option('v', "verbose", Default = false, HelpText = "Verbose logging. Includes output of all preparation steps.")>]
+        [<CommandLine.Option('v',
+                             "verbose",
+                             Default = false,
+                             HelpText = "Verbose logging. Includes output of all preparation steps.")>]
         Verbose : bool
-        [<Option("official", Required = false, HelpText = "A publicly available FCS NuGet version to test. Supports multiple values.")>]
+        [<Option("official",
+                 Required = false,
+                 HelpText = "A publicly available FCS NuGet version to test. Supports multiple values.")>]
         OfficialVersions : string seq
-        [<Option("local", Required = false, HelpText = "A local NuGet source to use for testing locally-generated FCS nupkg files. Supports multiple values.")>]
+        [<Option("local",
+                 Required = false,
+                 HelpText =
+                     "A local NuGet source to use for testing locally-generated FCS nupkg files. Supports multiple values.")>]
         LocalNuGetSourceDirs : string seq
-        [<Option("github", Required = false, HelpText = "An FSharp repository&revision, in the form 'owner/repo/revision' eg. 'dotnet/fsharp/5a72e586278150b7aea4881829cd37be872b2043. Supports multiple values.")>]
+        [<Option("github",
+                 Required = false,
+                 HelpText =
+                     "An FSharp repository&revision, in the form 'owner/repo/revision' eg. 'dotnet/fsharp/5a72e586278150b7aea4881829cd37be872b2043. Supports multiple values.")>]
         GitHubVersions : string seq
-        [<Option("record-otel-jaeger", Required = false, Default = false, HelpText = "If enabled, records and sends OpenTelemetry trace to a localhost Jaeger instance using the default port")>]
+        [<Option("record-otel-jaeger",
+                 Required = false,
+                 Default = false,
+                 HelpText =
+                     "If enabled, records and sends OpenTelemetry trace to a localhost Jaeger instance using the default port")>]
         RecordOtelJaeger : bool
-        [<Option("parallel-analysis", Default = ParallelAnalysisMode.Off, Required = false, HelpText = "Off = parallel analysis off, On = parallel analysis on, Compare = runs two benchmarks with parallel analysis on and off")>]
+        [<Option("parallel-analysis",
+                 Default = ParallelAnalysisMode.Off,
+                 Required = false,
+                 HelpText =
+                     "Off = parallel analysis off, On = parallel analysis on, Compare = runs two benchmarks with parallel analysis on and off")>]
         ParallelAnalysis : ParallelAnalysisMode
-        [<Option("gc", Default = GCMode.Workstation, Required = false, HelpText = "Whether to use 'workstation' or 'server' GC, or 'compare'.")>]
+        [<Option("gc",
+                 Default = GCMode.Workstation,
+                 Required = false,
+                 HelpText = "Whether to use 'workstation' or 'server' GC, or 'compare'.")>]
         GCMode : GCMode
     }
 
 let readSampleInput (sampleName : string) =
-    let assemblyDir = Path.GetDirectoryName(Assembly.GetAssembly(typeof<Args>).Location)
-    let path = Path.Combine(assemblyDir, "inputs", $"{sampleName}.json")
-    if File.Exists(path) then path
+    let assemblyDir =
+        Path.GetDirectoryName (Assembly.GetAssembly(typeof<Args>).Location)
+
+    let path = Path.Combine (assemblyDir, "inputs", $"{sampleName}.json")
+
+    if File.Exists (path) then
+        path
     else
-        let dir = Path.GetDirectoryName(path)
-        if Directory.Exists(dir) then
+        let dir = Path.GetDirectoryName (path)
+
+        if Directory.Exists (dir) then
             let samples =
-                Directory.EnumerateFiles(dir, "*.json")
+                Directory.EnumerateFiles (dir, "*.json")
                 |> Seq.map Path.GetFileNameWithoutExtension
+
             let samplesString =
-                let str = String.Join(", ", samples)
+                let str = String.Join (", ", samples)
                 $"[{str}]"
+
             failwith $"Sample {path} does not exist. Available samples are: {samplesString}"
         else
             failwith $"Samples directory '{dir}' does not exist"
 
 let prepareCase (args : Args) : BenchmarkCase =
-    use _ = LogContext.PushProperty("step", "Read input")
+    use _ = LogContext.PushProperty ("step", "Read input")
+
     try
         let path =
             match args.Input |> Option.ofObj, args.SampleInput |> Option.ofObj with
             | None, None -> failwith $"No input specified"
             | Some input, _ -> input
             | None, Some sample -> readSampleInput sample
-                    
-        log.Verbose("Read and deserialize inputs from {path}", path)
+
+        log.Verbose ("Read and deserialize inputs from {path}", path)
+
         path
         |> File.ReadAllText
         |> JsonConvert.DeserializeObject<BenchmarkCase>
         |> fun case ->
-                let defaultCodebasePrep =
-                    [
-                        {
-                            CodebasePrepStep.Command = "dotnet"
-                            CodebasePrepStep.Args = $"msbuild /t:Restore /p:RestoreUseStaticGraphEvaluation=true {case.SlnRelative}"
-                        }
-                    ]
-                let codebasePrep =
-                    match obj.ReferenceEquals(case.CodebasePrep, null) with
-                    | true -> defaultCodebasePrep
-                    | false -> case.CodebasePrep
-                
-                { case with CodebasePrep = codebasePrep }
+            let defaultCodebasePrep =
+                [
+                    {
+                        CodebasePrepStep.Command = "dotnet"
+                        CodebasePrepStep.Args =
+                            $"msbuild /t:Restore /p:RestoreUseStaticGraphEvaluation=true {case.SlnRelative}"
+                    }
+                ]
+
+            let codebasePrep =
+                match obj.ReferenceEquals (case.CodebasePrep, null) with
+                | true -> defaultCodebasePrep
+                | false -> case.CodebasePrep
+
+            { case with
+                CodebasePrep = codebasePrep
+            }
     with e ->
         let msg = $"Failed to read inputs file: {e.Message}"
-        log.Fatal(msg)
-        reraise()
+        log.Fatal (msg)
+        reraise ()
 
 type FCSVersionsArgs =
     {
         Official : string list
         Local : string list
         Git : string list
-    }    
+    }
 
 let prepareFCSVersions (config : Config) (raw : FCSVersionsArgs) =
     let official = raw.Official |> List.map NuGetFCSVersion.Official
     let local = raw.Local |> List.map NuGetFCSVersion.Local
+
     let git =
         raw.Git
         |> List.map (fun specStr ->
-            let m = Regex.Match(specStr, "^([0-9a-zA-Z_\-]+)/([0-9a-zA-Z_\-]+)/([0-9a-zA-Z_\-]+)$")
+            let m =
+                Regex.Match (specStr, "^([0-9a-zA-Z_\-]+)/([0-9a-zA-Z_\-]+)/([0-9a-zA-Z_\-]+)$")
+
             if m.Success then
                 let owner, repo, revision = m.Groups[1].Value, m.Groups[2].Value, m.Groups[3].Value
                 let url = $"https://github.com/{owner}/{repo}"
-                let spec = FCSRepoSpec.Custom {GitUrl = url; Revision = revision}
+                let spec = FCSRepoSpec.Custom { GitUrl = url ; Revision = revision }
                 let checkout = checkoutAndBuild config spec
                 NuGetFCSVersion.Local checkout.Dir
             else
                 failwith $"Invalid GitHub FCS repo spec: {specStr}. Expected format: 'owner/repo/revision'"
         )
+
     local @ official @ git
     |> function
         | [] -> failwith "At least one version must be specified"
         | versions -> versions
 
 let run (args : Args) : unit =
-    log <- LoggerConfiguration().Enrich.FromLogContext()
-               .WriteTo.Console(outputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3}] {step:j}: {Message:lj}{NewLine}{Exception}")
-               .MinimumLevel.Is(if args.Verbose then LogEventLevel.Verbose else LogEventLevel.Information)
-               .CreateLogger()
+    log <-
+        LoggerConfiguration()
+            .Enrich.FromLogContext()
+            .WriteTo
+            .Console(
+                outputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3}] {step:j}: {Message:lj}{NewLine}{Exception}"
+            )
+            .MinimumLevel
+            .Is(
+                if args.Verbose then
+                    LogEventLevel.Verbose
+                else
+                    LogEventLevel.Information
+            )
+            .CreateLogger ()
+
     try
-        log.Verbose("CLI args provided:" + Environment.NewLine + "{args}", args)
+        log.Verbose ("CLI args provided:" + Environment.NewLine + "{args}", args)
+
         let config =
             {
                 Config.BaseDir = args.CheckoutsDir
                 Config.ForceFCSBuild = args.ForceFCSBuild
             }
-        
-        let rawVersions = { Official = args.OfficialVersions |> Seq.toList; Local = args.LocalNuGetSourceDirs |> Seq.toList; Git = args.GitHubVersions |> Seq.toList }
+
+        let rawVersions =
+            {
+                Official = args.OfficialVersions |> Seq.toList
+                Local = args.LocalNuGetSourceDirs |> Seq.toList
+                Git = args.GitHubVersions |> Seq.toList
+            }
+
         let versions = prepareFCSVersions config rawVersions
         let case = prepareCase args
-        
-        use _ = LogContext.PushProperty("step", "PrepareAndRun")
-        prepareAndRun config case args.DryRun args.Cleanup args.Iterations args.Warmups args.RecordOtelJaeger args.ParallelAnalysis args.GCMode versions
+
+        use _ = LogContext.PushProperty ("step", "PrepareAndRun")
+
+        prepareAndRun
+            config
+            case
+            args.DryRun
+            args.Cleanup
+            args.Iterations
+            args.Warmups
+            args.RecordOtelJaeger
+            args.ParallelAnalysis
+            args.GCMode
+            versions
     with ex ->
         if args.Verbose then
-            log.Fatal(ex, "Failure.")
+            log.Fatal (ex, "Failure.")
         else
-            log.Fatal(ex, "Failure. Consider using --verbose for extra information.")
+            log.Fatal (ex, "Failure. Consider using --verbose for extra information.")
 
 [<EntryPoint>]
 [<MethodImpl(MethodImplOptions.NoInlining)>]
 let main args =
     let parseResult = Parser.Default.ParseArguments<Args> args
-    parseResult.WithParsed(run)
-    |> ignore    
+    parseResult.WithParsed (run) |> ignore
     if parseResult.Tag = ParserResultType.Parsed then 0 else 1

--- a/Generator.fsproj
+++ b/Generator.fsproj
@@ -7,6 +7,7 @@
         <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
         <Description>A tool for generating and running high-level benchmarks of the FSharp compiler service (FCS)</Description>
         <NoWarn>NU1608</NoWarn>
+        <WarningsAsErrors>FS0025</WarningsAsErrors>
 
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/Git.fs
+++ b/Git.fs
@@ -7,26 +7,32 @@ open LibGit2Sharp
 let clone (dir : string) (gitUrl : string) : Repository =
     if Directory.Exists dir then
         failwith $"{dir} already exists for code root"
-    log.Verbose("Fetching '{gitUrl}' in '{dir}'", gitUrl, dir)
-    Repository.Init(dir) |> ignore
-    let repo = new Repository(dir)
-    let remote = repo.Network.Remotes.Add("origin", gitUrl)
-    repo.Network.Fetch(remote.Name, [])
-    repo
-    
-let checkout (repo : Repository) (revision : string) : unit =
-    log.Verbose("Checkout revision {revision} in {repo.Info.Path}", revision, repo.Info.Path)
-    Commands.Checkout(repo, revision) |> ignore
 
-let revisionDir (baseDir : string) (revision : string) =
-    Path.Combine(baseDir, revision)
+    log.Verbose ("Fetching '{gitUrl}' in '{dir}'", gitUrl, dir)
+    Repository.Init (dir) |> ignore
+    let repo = new Repository (dir)
+    let remote = repo.Network.Remotes.Add ("origin", gitUrl)
+    repo.Network.Fetch (remote.Name, [])
+    repo
+
+let checkout (repo : Repository) (revision : string) : unit =
+    log.Verbose ("Checkout revision {revision} in {repo.Info.Path}", revision, repo.Info.Path)
+    Commands.Checkout (repo, revision) |> ignore
+
+let revisionDir (baseDir : string) (revision : string) = Path.Combine (baseDir, revision)
 
 let prepareRevisionCheckout (baseDir : string) (repoUrl : string) (revision : string) =
     let dir = revisionDir baseDir revision
+
     if Repository.IsValid dir |> not then
         printfn $"Checking out revision {revision} in {dir}"
-        try Directory.Delete dir with _ -> ()
+
+        try
+            Directory.Delete dir
+        with _ ->
+            ()
+
         use repo = clone dir repoUrl
-        checkout repo revision 
+        checkout repo revision
     else
         printfn $"{revision} already checked out in {dir}"

--- a/RepoSetup.fs
+++ b/RepoSetup.fs
@@ -11,7 +11,9 @@ type RepoSpec =
         GitUrl : string
         Revision : string
     }
-    with override this.ToString() = $"{this.Name} ({this.GitUrl}) @ {this.Revision}"
+
+    override this.ToString () =
+        $"{this.Name} ({this.GitUrl}) @ {this.Revision}"
 
 type Config =
     {
@@ -20,15 +22,20 @@ type Config =
     }
 
 let revisionDir (config : Config) (spec : RepoSpec) : string =
-    Path.Combine(config.BaseDir, spec.Name, spec.Revision)
+    Path.Combine (config.BaseDir, spec.Name, spec.Revision)
 
 let prepareRepo (config : Config) (spec : RepoSpec) : Repository =
-    log.Information("Preparing repo {spec}", spec)
+    log.Information ("Preparing repo {spec}", spec)
     let dir = revisionDir config spec
+
     if Repository.IsValid dir |> not then
         use repo = Git.clone dir spec.GitUrl
         Git.checkout repo spec.Revision
         repo
     else
-        log.Information("{dir} already exists and is a git repository - will assume the repository revision is already checked out", dir)
-        new Repository(dir)
+        log.Information (
+            "{dir} already exists and is a git repository - will assume the repository revision is already checked out",
+            dir
+        )
+
+        new Repository (dir)

--- a/Runner/Runner.fs
+++ b/Runner/Runner.fs
@@ -29,71 +29,81 @@ open OpenTelemetry.Trace
 
 
 type DisposableTempDir() =
-    let path = Path.GetTempFileName()
-    do
-        File.Delete(path)
-    let dir = Directory.CreateDirectory(path)
-    
+    let path = Path.GetTempFileName ()
+    do File.Delete (path)
+    let dir = Directory.CreateDirectory (path)
+
     interface IDisposable with
-        member _.Dispose() =
+        member _.Dispose () =
             if dir.Exists then
                 try
-                    dir.Delete()
-                with e -> printfn $"Failed to delete temp directory {dir.FullName}"
-    
+                    dir.Delete ()
+                with e ->
+                    printfn $"Failed to delete temp directory {dir.FullName}"
+
     member this.Dir = dir
 
 let copyDirContents sourceDir targetDir =
-    Directory.EnumerateFiles(sourceDir)
-    |> Seq.iter (fun sourceFile ->
-        File.Copy(sourceFile, Path.Combine(targetDir, Path.GetFileName(sourceFile)))
-    )
+    Directory.EnumerateFiles (sourceDir)
+    |> Seq.iter (fun sourceFile -> File.Copy (sourceFile, Path.Combine (targetDir, Path.GetFileName (sourceFile))))
 
-let time = ((DateTimeOffset)DateTime.Now).ToUnixTimeSeconds()
+let time = ((DateTimeOffset) DateTime.Now).ToUnixTimeSeconds ()
 let mutable nugetCounter = 1
+
 let createHackedNugetSourceDir (dir : string) =
-    let copy = new DisposableTempDir()
+    let copy = new DisposableTempDir ()
     copyDirContents dir copy.Dir.FullName
+
     let nupkg =
-        copy.Dir.EnumerateFiles($"FSharp.Compiler.Service.*.nupkg")
-        |> Seq.exactlyOne
-    use c = new DisposableTempDir()
-    ZipFile.ExtractToDirectory(nupkg.FullName, c.Dir.FullName)
-    let nuspec = Path.Combine(c.Dir.FullName, "FSharp.Compiler.Service.nuspec")
-    let text = File.ReadAllText(nuspec)
+        copy.Dir.EnumerateFiles ($"FSharp.Compiler.Service.*.nupkg") |> Seq.exactlyOne
+
+    use c = new DisposableTempDir ()
+    ZipFile.ExtractToDirectory (nupkg.FullName, c.Dir.FullName)
+    let nuspec = Path.Combine (c.Dir.FullName, "FSharp.Compiler.Service.nuspec")
+    let text = File.ReadAllText (nuspec)
     let newVersion = $"1000.{time}.{nugetCounter}"
-    let replaced = Regex.Replace(text, "<version>.+</version>", $"<version>{newVersion}</version>")
+
+    let replaced =
+        Regex.Replace (text, "<version>.+</version>", $"<version>{newVersion}</version>")
+
     nugetCounter <- nugetCounter + 1
-    File.WriteAllText(nuspec, replaced)
-    nupkg.Delete()
-    ZipFile.CreateFromDirectory(c.Dir.FullName, nupkg.FullName)
+    File.WriteAllText (nuspec, replaced)
+    nupkg.Delete ()
+    ZipFile.CreateFromDirectory (c.Dir.FullName, nupkg.FullName)
     printfn $"Hacked NuGet source dir from {dir} to {copy.Dir.FullName}"
     copy.Dir, newVersion
 
 
 [<MemoryDiagnoser>]
-type Benchmark () =
-    
+type Benchmark() =
+
     let printDiagnostics (results : FSharpCheckFileResults) =
         match results.Diagnostics with
         | [||] -> ()
         | diagnostics ->
             printfn $"{diagnostics.Length} issues/diagnostics found:"
+
             for d in diagnostics do
                 printfn $"- {d.Message}"
-    
+
     let cleanCaches (checker : FSharpChecker) =
-        checker.InvalidateAll()
-        checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients()
-    
+        checker.InvalidateAll ()
+        checker.ClearLanguageServiceRootCachesAndCollectAndFinalizeAllTransients ()
+
     let performAction (checker : FSharpChecker) (action : BenchmarkAction) =
         match action with
         | AnalyseFile x ->
-            [1..x.Repeat]
+            [ 1 .. x.Repeat ]
             |> List.map (fun _ ->
                 let result, answer =
-                    checker.ParseAndCheckFileInProject(x.FileName, x.FileVersion, FSharp.Compiler.Text.SourceText.ofString x.SourceText, x.Options)
+                    checker.ParseAndCheckFileInProject (
+                        x.FileName,
+                        x.FileVersion,
+                        FSharp.Compiler.Text.SourceText.ofString x.SourceText,
+                        x.Options
+                    )
                     |> Async.RunSynchronously
+
                 match answer with
                 | FSharpCheckFileAnswer.Aborted -> failwith "checker aborted"
                 | FSharpCheckFileAnswer.Succeeded results ->
@@ -101,116 +111,150 @@ type Benchmark () =
                     cleanCaches checker
                     action, (result, answer)
             )
-            
+
     let mutable setup : (FSharpChecker * BenchmarkAction list) option = None
     let mutable tracerProvider : TracerProvider option = None
-    
+
     static member InputEnvironmentVariable = "FcsBenchmarkInput"
     static member OtelEnvironmentVariable = "FcsBenchmarkRecordOtelJaeger"
     static member ParallelProjectsAnalysisEnvironmentVariable = "FCS_PARALLEL_PROJECTS_ANALYSIS"
-        
-    member _.SetupTelemetry() =
+
+    member _.SetupTelemetry () =
         let useTracing =
-            match Environment.GetEnvironmentVariable(Benchmark.OtelEnvironmentVariable) |> bool.TryParse with
+            match
+                Environment.GetEnvironmentVariable (Benchmark.OtelEnvironmentVariable)
+                |> bool.TryParse
+            with
             | true, useTelemetry -> useTelemetry
             | false, _ -> false
-        
+
         tracerProvider <-
             if useTracing then
-                Sdk.CreateTracerProviderBuilder()
-                   .AddSource("fsc")
-                   .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(serviceName="program", serviceVersion = "42.42.42.44"))
-                   .AddJaegerExporter(fun c ->
-                       // c.BatchExportProcessorOptions.MaxQueueSize <- 10000000
-                       // c.BatchExportProcessorOptions.MaxExportBatchSize <- 10000000
-                       c.ExportProcessorType <- ExportProcessorType.Simple
-                       //c.MaxPayloadSizeInBytes <- Nullable(1000000000)
+                Sdk
+                    .CreateTracerProviderBuilder()
+                    .AddSource("fsc")
+                    .SetResourceBuilder(
+                        ResourceBuilder
+                            .CreateDefault()
+                            .AddService (serviceName = "program", serviceVersion = "42.42.42.44")
                     )
-                   .Build()
+                    .AddJaegerExporter(fun c ->
+                        // c.BatchExportProcessorOptions.MaxQueueSize <- 10000000
+                        // c.BatchExportProcessorOptions.MaxExportBatchSize <- 10000000
+                        c.ExportProcessorType <- ExportProcessorType.Simple
+                    //c.MaxPayloadSizeInBytes <- Nullable(1000000000)
+                    )
+                    .Build ()
                 |> Some
             else
                 None
-    
-    static member ReadInput(inputFile : string) =
-        if File.Exists(inputFile) then
+
+    static member ReadInput (inputFile : string) =
+        if File.Exists (inputFile) then
             printfn $"Deserializing inputs from '{inputFile}'"
-            let json = File.ReadAllText(inputFile)
+            let json = File.ReadAllText (inputFile)
             deserializeInputs json
         else
             failwith $"Input file '{inputFile}' does not exist"
-    
+
     [<GlobalSetup>]
-    member this.Setup() =
-        let inputFile = Environment.GetEnvironmentVariable(Benchmark.InputEnvironmentVariable)
-        if File.Exists(inputFile) then
-            let inputs = Benchmark.ReadInput(inputFile)
-            let checker = FSharpChecker.Create(projectCacheSize = inputs.Config.ProjectCacheSize)
+    member this.Setup () =
+        let inputFile =
+            Environment.GetEnvironmentVariable (Benchmark.InputEnvironmentVariable)
+
+        if File.Exists (inputFile) then
+            let inputs = Benchmark.ReadInput (inputFile)
+
+            let checker =
+                FSharpChecker.Create (projectCacheSize = inputs.Config.ProjectCacheSize)
+
             setup <- (checker, inputs.Actions) |> Some
         else
             failwith $"Input file '{inputFile}' does not exist"
-        this.SetupTelemetry()
+
+        this.SetupTelemetry ()
 
     [<Benchmark>]
-    member _.Run() =
+    member _.Run () =
         match setup with
         | None -> failwith "Setup did not run"
         | Some (checker, actions) ->
             for action in actions do
-                performAction checker action
-                |> ignore
+                performAction checker action |> ignore
 
     [<IterationCleanup>]
-    member _.Cleanup() =
-        setup
-        |> Option.iter (fun (checker, _) -> cleanCaches checker)
+    member _.Cleanup () =
+        setup |> Option.iter (fun (checker, _) -> cleanCaches checker)
+
         match tracerProvider with
-        | Some tracerProvider ->
-            tracerProvider.ForceFlush() |> ignore
+        | Some tracerProvider -> tracerProvider.ForceFlush () |> ignore
         | None -> ()
-        
+
     [<GlobalCleanup>]
-    member _.GlobalCleanup() =
-        tracerProvider
-        |> Option.iter (fun prov -> prov.Dispose())
-        
+    member _.GlobalCleanup () =
+        tracerProvider |> Option.iter (fun prov -> prov.Dispose ())
+
 [<RequireQualifiedAccess>]
 type NuGetFCSVersion =
     | Official of version : string
     | Local of sourceDir : string
-    
+
 module NuGet =
 
     let private fcsPackageName = "FSharp.Compiler.Service"
     let private fsharpCorePackageName = "FSharp.Core"
 
     let findFSharpCoreVersion (fcsVersion : string) =
-        use cache = new SourceCacheContext()
-        let repo = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json")
-        let r = repo.GetResource<PackageMetadataResource>()
-        let x = r.GetMetadataAsync(PackageIdentity("FSharp.Compiler.Service", NuGetVersion(fcsVersion)), cache, NullLogger.Instance, CancellationToken.None).Result
+        use cache = new SourceCacheContext ()
+        let repo = Repository.Factory.GetCoreV3 ("https://api.nuget.org/v3/index.json")
+        let r = repo.GetResource<PackageMetadataResource> ()
+
+        let x =
+            r
+                .GetMetadataAsync(
+                    PackageIdentity ("FSharp.Compiler.Service", NuGetVersion (fcsVersion)),
+                    cache,
+                    NullLogger.Instance,
+                    CancellationToken.None
+                )
+                .Result
+
         let y = x.DependencySets |> Seq.head
         let core = y.Packages |> Seq.find (fun d -> d.Id = "FSharp.Core")
         core.VersionRange.MinVersion
 
     let officialNuGet (version : string) =
         let core = findFSharpCoreVersion version
+
         [
-            NuGetReference(fcsPackageName, version, prerelease=false)
-            NuGetReference("FSharp.Core", core.OriginalVersion, prerelease=false)
+            NuGetReference (fcsPackageName, version, prerelease = false)
+            NuGetReference ("FSharp.Core", core.OriginalVersion, prerelease = false)
         ]
 
     let extractNuPkgVersion (packageName : string) (file : string) : string option =
-        match System.Text.RegularExpressions.Regex.Match(file.ToLowerInvariant(), $".*{packageName.ToLowerInvariant()}.([0-9_\-\.]+).nupkg") with
+        match
+            System.Text.RegularExpressions.Regex.Match (
+                file.ToLowerInvariant (),
+                $".*{packageName.ToLowerInvariant ()}.([0-9_\-\.]+).nupkg"
+            )
+        with
         | res when res.Success -> res.Groups[1].Value |> Some
         | _ -> None
-        
+
     let inferLocalNuGetVersion (sourceDir : string) (packageName : string) =
-        let files = Directory.EnumerateFiles(sourceDir, $"{packageName}.*.nupkg") |> Seq.toArray
-        let x = files|> Array.choose (extractNuPkgVersion packageName)
+        let files =
+            Directory.EnumerateFiles (sourceDir, $"{packageName}.*.nupkg") |> Seq.toArray
+
+        let x = files |> Array.choose (extractNuPkgVersion packageName)
         x |> Array.exactlyOne
 
     let localNuGet (sourceDir : string) =
-        let candidateDirs = [sourceDir; Path.Combine(sourceDir, "artifacts", "packages", "Release", "Release")]
+        let candidateDirs =
+            [
+                sourceDir
+                Path.Combine (sourceDir, "artifacts", "packages", "Release", "Release")
+            ]
+
         candidateDirs
         |> List.choose (fun sourceDir ->
             try
@@ -218,35 +262,41 @@ module NuGet =
                     fcsPackageName, inferLocalNuGetVersion sourceDir fcsPackageName
                     fsharpCorePackageName, inferLocalNuGetVersion sourceDir fsharpCorePackageName
                 ]
-                |> List.map (fun (name, version) -> NuGetReference(name, version, Uri(sourceDir), prerelease=false))
+                |> List.map (fun (name, version) -> NuGetReference (name, version, Uri (sourceDir), prerelease = false))
                 |> Some
-            with _ -> None
+            with _ ->
+                None
         )
         |> function
             | [] ->
                 let candidateDirsString =
-                    String.Join(Environment.NewLine, candidateDirs |> List.map (fun dir -> $" - {dir}"))
-                failwith $"Could not find nupkg files with sourceDir='{sourceDir}.'\n\
+                    String.Join (Environment.NewLine, candidateDirs |> List.map (fun dir -> $" - {dir}"))
+
+                failwith
+                    $"Could not find nupkg files with sourceDir='{sourceDir}.'\n\
                                Attempted the following candidate directories:\n\
                                {candidateDirsString}"
             | head :: _ ->
                 let source = head[0].PackageSource.LocalPath
                 let source, version = createHackedNugetSourceDir source
+
                 head
                 |> List.map (fun ref ->
-                    let version = match ref.PackageName with "FSharp.Compiler.Service" -> version | _ -> ref.PackageVersion
-                    NuGetReference(ref.PackageName, version, Uri(source.FullName), ref.Prerelease)
+                    let version =
+                        match ref.PackageName with
+                        | "FSharp.Compiler.Service" -> version
+                        | _ -> ref.PackageVersion
+
+                    NuGetReference (ref.PackageName, version, Uri (source.FullName), ref.Prerelease)
                 )
-                
+
     let makeReference (version : NuGetFCSVersion) =
         match version with
         | NuGetFCSVersion.Official version -> officialNuGet version
         | NuGetFCSVersion.Local source -> localNuGet source
-                
+
     let makeReferenceList (version : NuGetFCSVersion) : NuGetReferenceList =
-        version
-        |> makeReference
-        |> NuGetReferenceList
+        version |> makeReference |> NuGetReferenceList
 
 type RunnerArgs =
     {
@@ -254,91 +304,125 @@ type RunnerArgs =
         Input : string seq
         [<Option("official", Required = false, HelpText = "List of official NuGet versions of FCS to test")>]
         OfficialVersions : string seq
-        [<Option("local", Required = false, HelpText = "List of local NuGet source directories to use as sources of FCS dll to test")>]
+        [<Option("local",
+                 Required = false,
+                 HelpText = "List of local NuGet source directories to use as sources of FCS dll to test")>]
         LocalNuGetSourceDirs : string seq
-        [<Option("iterations", Required = false, Default = 1, HelpText = "Number of iterations - BDN's '--iteration-count'")>]
+        [<Option("iterations",
+                 Required = false,
+                 Default = 1,
+                 HelpText = "Number of iterations - BDN's '--iteration-count'")>]
         Iterations : int
         [<Option("warmups", Required = false, Default = 1, HelpText = "Number of warmups")>]
         Warmups : int
         [<Option("artifacts-path", Required = false, HelpText = "BDN Artifacts output path")>]
         ArtifactsPath : string
-        [<Option("record-otel-jaeger", Required = false, Default = false, HelpText = "If enabled, records and sends OpenTelemetry trace to a localhost Jaeger instance using the default port")>]
+        [<Option("record-otel-jaeger",
+                 Required = false,
+                 Default = false,
+                 HelpText =
+                     "If enabled, records and sends OpenTelemetry trace to a localhost Jaeger instance using the default port")>]
         RecordOtelJaeger : bool
-        [<Option("parallel-analysis", Default = ParallelAnalysisMode.Off, Required = false, HelpText = "Off = parallel analysis off, On = parallel analysis on, Compare = runs two benchmarks with parallel analysis on and off")>]
+        [<Option("parallel-analysis",
+                 Default = ParallelAnalysisMode.Off,
+                 Required = false,
+                 HelpText =
+                     "Off = parallel analysis off, On = parallel analysis on, Compare = runs two benchmarks with parallel analysis on and off")>]
         ParallelAnalysis : ParallelAnalysisMode
-        [<Option("gc", Default = GCMode.Workstation, Required = false, HelpText = "Whether to use 'workstation' or 'server' GC, or 'compare'.")>]
+        [<Option("gc",
+                 Default = GCMode.Workstation,
+                 Required = false,
+                 HelpText = "Whether to use 'workstation' or 'server' GC, or 'compare'.")>]
         GCMode : GCMode
     }
 
 let private makeConfig (versions : NuGetFCSVersion list) (args : RunnerArgs) : IConfig =
     let baseJob =
-        Job.ShortRun
-            .WithWarmupCount(args.Warmups)
-            .WithIterationCount(args.Iterations)
+        Job.ShortRun.WithWarmupCount(args.Warmups).WithIterationCount (args.Iterations)
+
     let inputs = args.Input |> Seq.toList
+
     let parallelAnalysisModes =
         match args.ParallelAnalysis with
-        | ParallelAnalysisMode.Off -> [false]
-        | ParallelAnalysisMode.On -> [true]
-        | ParallelAnalysisMode.Compare -> [true; false]
+        | ParallelAnalysisMode.Off -> [ false ]
+        | ParallelAnalysisMode.On -> [ true ]
+        | ParallelAnalysisMode.Compare -> [ true ; false ]
         | unknown -> failwith $"Unrecognised value of 'parallelAnalysisMode': {unknown}"
-    
+
     let gcModes =
         match args.GCMode with
-        | GCMode.Workstation -> [GCMode.Workstation]
-        | GCMode.Server -> [GCMode.Server]
-        | GCMode.Compare -> [GCMode.Server; GCMode.Workstation]
+        | GCMode.Workstation -> [ GCMode.Workstation ]
+        | GCMode.Server -> [ GCMode.Server ]
+        | GCMode.Compare -> [ GCMode.Server ; GCMode.Workstation ]
         | unknown -> failwith $"Unrecognised value of 'gcMode': {unknown}"
-        
+
     let versionsSources =
         versions
         |> List.map (fun version ->
-            let versionName = match version with NuGetFCSVersion.Official v -> v | NuGetFCSVersion.Local source -> source
+            let versionName =
+                match version with
+                | NuGetFCSVersion.Official v -> v
+                | NuGetFCSVersion.Local source -> source
+
             let refs = NuGet.makeReferenceList version
             versionName, refs
         )
-        
-    let combinations = List.allPairs (List.allPairs (List.allPairs inputs versionsSources) parallelAnalysisModes) gcModes
+
+    let combinations =
+        List.allPairs (List.allPairs (List.allPairs inputs versionsSources) parallelAnalysisModes) gcModes
+
     let jobs =
         combinations
-        |> List.mapi (
-            fun i (((input, (versionName, refs)), parallelAnalysisMode), gcMode) ->
-                let useServerGc = gcMode = GCMode.Server
-                let jobName = $"fcs={versionName}_parallel={parallelAnalysisMode}_serverGc={useServerGc}"
-                let job =
-                    baseJob
-                        .WithNuGet(refs)
-                        .WithEnvironmentVariable(Benchmark.InputEnvironmentVariable, input)
-                        .WithEnvironmentVariable(Benchmark.ParallelProjectsAnalysisEnvironmentVariable, parallelAnalysisMode.ToString())
-                        .WithEnvironmentVariable(Benchmark.OtelEnvironmentVariable, if args.RecordOtelJaeger then "true" else "false")
-                        .WithGcServer(useServerGc)
-                        .WithId(jobName)
-                job
+        |> List.mapi (fun i (((input, (versionName, refs)), parallelAnalysisMode), gcMode) ->
+            let useServerGc = gcMode = GCMode.Server
+
+            let jobName =
+                $"fcs={versionName}_parallel={parallelAnalysisMode}_serverGc={useServerGc}"
+
+            let job =
+                baseJob
+                    .WithNuGet(refs)
+                    .WithEnvironmentVariable(Benchmark.InputEnvironmentVariable, input)
+                    .WithEnvironmentVariable(
+                        Benchmark.ParallelProjectsAnalysisEnvironmentVariable,
+                        parallelAnalysisMode.ToString ()
+                    )
+                    .WithEnvironmentVariable(
+                        Benchmark.OtelEnvironmentVariable,
+                        if args.RecordOtelJaeger then "true" else "false"
+                    )
+                    .WithGcServer(useServerGc)
+                    .WithId (jobName)
+
+            job
         )
-    
+
     let d = DefaultConfig.Instance
-    let defaultArtifactsPath = Path.Combine(Environment.CurrentDirectory, "FCSBenchmark.Artifacts")
+
+    let defaultArtifactsPath =
+        Path.Combine (Environment.CurrentDirectory, "FCSBenchmark.Artifacts")
+
     let artifactsPath =
-        args.ArtifactsPath
-        |> Option.ofObj
-        |> Option.defaultValue defaultArtifactsPath
+        args.ArtifactsPath |> Option.ofObj |> Option.defaultValue defaultArtifactsPath
+
+    let config = ManualConfig.CreateEmpty().WithArtifactsPath (artifactsPath)
+    let config = config.AddLogger (BenchmarkDotNet.Loggers.NullLogger.Instance)
+    let config = config.AddExporter (d.GetExporters () |> Seq.toArray)
+    let config = config.AddAnalyser (d.GetAnalysers () |> Seq.toArray)
+    let config = config.AddColumnProvider (d.GetColumnProviders () |> Seq.toArray)
+    let config = config.AddDiagnoser (d.GetDiagnosers () |> Seq.toArray)
+    let config = config.AddValidator (d.GetValidators () |> Seq.toArray)
+    let config = config.AddExporter (JsonExporter (indentJson = true))
+
     let config =
-        ManualConfig.CreateEmpty().WithArtifactsPath(artifactsPath)
-    let config = config.AddLogger(BenchmarkDotNet.Loggers.NullLogger.Instance)
-    let config = config.AddExporter(d.GetExporters() |> Seq.toArray)
-    let config = config.AddAnalyser(d.GetAnalysers() |> Seq.toArray)
-    let config = config.AddColumnProvider(d.GetColumnProviders() |> Seq.toArray)
-    let config = config.AddDiagnoser(d.GetDiagnosers() |> Seq.toArray)
-    let config = config.AddValidator(d.GetValidators() |> Seq.toArray)
-    let config = config.AddExporter(JsonExporter(indentJson = true))
-    let config = List.fold (fun (config : IConfig) (job : Job) -> config.AddJob(job)) config jobs
+        List.fold (fun (config : IConfig) (job : Job) -> config.AddJob (job)) config jobs
+
     config
 
 let parseVersions (officialVersions : string seq) (localNuGetSourceDirs : string seq) =
     let official = officialVersions |> Seq.map NuGetFCSVersion.Official
     let local = localNuGetSourceDirs |> Seq.map NuGetFCSVersion.Local
-    Seq.append official local
-    |> Seq.toList
+    Seq.append official local |> Seq.toList
 
 let runStandard args =
     let versions =
@@ -346,22 +430,22 @@ let runStandard args =
         |> function
             | [] -> failwith "At least one version must be specified"
             | versions -> versions
-    
+
     let defaultConfig = makeConfig versions args
-    let summary = BenchmarkRunner.Run(typeof<Benchmark>, defaultConfig)
-    let analyser = summary.BenchmarksCases[0].Config.GetCompositeAnalyser()
-    let conclusions = List<Conclusion>(analyser.Analyse(summary))
-    MarkdownExporter.Console.ExportToLog(summary, ConsoleLogger.Default)
-    ConclusionHelper.Print(ConsoleLogger.Ascii, conclusions)
+    let summary = BenchmarkRunner.Run (typeof<Benchmark>, defaultConfig)
+    let analyser = summary.BenchmarksCases[ 0 ].Config.GetCompositeAnalyser ()
+    let conclusions = List<Conclusion> (analyser.Analyse (summary))
+    MarkdownExporter.Console.ExportToLog (summary, ConsoleLogger.Default)
+    ConclusionHelper.Print (ConsoleLogger.Ascii, conclusions)
     printfn $"Full Log available in '{summary.LogFilePath}'"
     printfn $"Reports available in '{summary.ResultsDirectoryPath}'"
     0
 
 [<EntryPoint>]
 let main args =
-    use parser = new Parser(fun x -> x.IgnoreUnknownArguments <- false)
-    let result = parser.ParseArguments<RunnerArgs>(args)
+    use parser = new Parser (fun x -> x.IgnoreUnknownArguments <- false)
+    let result = parser.ParseArguments<RunnerArgs> (args)
+
     match result with
-    | :? Parsed<RunnerArgs> as parsed ->
-        runStandard parsed.Value
+    | :? Parsed<RunnerArgs> as parsed -> runStandard parsed.Value
     | _ -> failwith "Parse error"

--- a/Runner/Runner.fsproj
+++ b/Runner/Runner.fsproj
@@ -6,6 +6,7 @@
         <OutputType>exe</OutputType>
         <Configurations>Release</Configurations>
         <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+        <WarningsAsErrors>FS0025</WarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Serialisation/Dtos.fs
+++ b/Serialisation/Dtos.fs
@@ -1,6 +1,7 @@
 ﻿/// This file is shared between FCSBenchmark.Generator that serializes inputs using these DTO types,
 /// and FCSBenchmark.Runner that deserializes them using these DTO types.
 module FCSBenchmark.Common.Dtos
+
 #nowarn "40"
 
 open System.Collections.Generic
@@ -12,24 +13,24 @@ open Newtonsoft.Json
 [<CLIMutable>]
 type AnalyseFileDto =
     {
-        FileName: string
-        FileVersion: int
-        SourceText: string
-        Options: FSharpProjectOptionsDto
+        FileName : string
+        FileVersion : int
+        SourceText : string
+        Options : FSharpProjectOptionsDto
         [<DefaultValue(1)>]
         Repeat : int
     }
 
-type BenchmarkActionDto =
-    | AnalyseFile of AnalyseFileDto
+type BenchmarkActionDto = | AnalyseFile of AnalyseFileDto
 
-[<CLIMutable>]    
+[<CLIMutable>]
 type BenchmarkConfig =
     {
         ProjectCacheSize : int
     }
-    with static member makeDefault () = {ProjectCacheSize = 200}
-    
+
+    static member makeDefault () = { ProjectCacheSize = 200 }
+
 [<CLIMutable>]
 type BenchmarkInputsDto =
     {
@@ -40,16 +41,15 @@ type BenchmarkInputsDto =
 /// Defines a call to BackgroundChecker.ParseAndCheckFileInProject(fileName: string, fileVersion, sourceText: ISourceText, options: FSharpProjectOptions, userOpName) =
 type AnalyseFile =
     {
-        FileName: string
-        FileVersion: int
-        SourceText: string
-        Options: FSharpProjectOptions
-        Repeat: int
+        FileName : string
+        FileVersion : int
+        SourceText : string
+        Options : FSharpProjectOptions
+        Repeat : int
     }
 
-type BenchmarkAction =
-    | AnalyseFile of AnalyseFile
-    
+type BenchmarkAction = | AnalyseFile of AnalyseFile
+
 type BenchmarkInputs =
     {
         Actions : BenchmarkAction list
@@ -95,29 +95,29 @@ let private actionFromDto =
 let private inputsFromDto =
     fun (dto : BenchmarkInputsDto) ->
         {
-            BenchmarkInputs.Actions = dto.Actions.ToArray() |> Seq.map actionFromDto |> Seq.toList 
+            BenchmarkInputs.Actions = dto.Actions.ToArray () |> Seq.map actionFromDto |> Seq.toList
             Config = dto.Config
         }
     |> memoizeUsingRefComparison
 
 let jsonSerializerSettings =
-    JsonSerializerSettings(
-        PreserveReferencesHandling = PreserveReferencesHandling.All
-    )
+    JsonSerializerSettings (PreserveReferencesHandling = PreserveReferencesHandling.All)
 
 let serializeInputs (inputs : BenchmarkInputs) : string =
     let dto = inputs |> inputsToDtos
-    JsonConvert.SerializeObject(dto, Formatting.Indented, jsonSerializerSettings)
-        
+    JsonConvert.SerializeObject (dto, Formatting.Indented, jsonSerializerSettings)
+
 let deserializeInputs (json : string) : BenchmarkInputs =
-    let dto = JsonConvert.DeserializeObject<BenchmarkInputsDto>(json, jsonSerializerSettings)
+    let dto =
+        JsonConvert.DeserializeObject<BenchmarkInputsDto> (json, jsonSerializerSettings)
+
     inputsFromDto dto
-    
+
 type ParallelAnalysisMode =
     | Off = 0
     | On = 1
     | Compare = 2
-    
+
 type GCMode =
     | Workstation = 0
     | Server = 1

--- a/Serialisation/Dtos.fs
+++ b/Serialisation/Dtos.fs
@@ -21,7 +21,18 @@ type AnalyseFileDto =
         Repeat : int
     }
 
-type BenchmarkActionDto = | AnalyseFile of AnalyseFileDto
+[<CLIMutable>]
+type BuildProjectDto =
+    {
+        Args : string array
+        ProjectFileName : string
+        [<DefaultValue(1)>]
+        Repeat : int
+    }
+
+type BenchmarkActionDto =
+    | AnalyseFile of AnalyseFileDto
+    | BuildProject of BuildProjectDto
 
 [<CLIMutable>]
 type BenchmarkConfig =
@@ -48,7 +59,17 @@ type AnalyseFile =
         Repeat : int
     }
 
-type BenchmarkAction = | AnalyseFile of AnalyseFile
+/// Defines a call to BackgroundChecker.Compile(argv: string array) =
+type BuildProject =
+    {
+        Args : string array
+        ProjectFileName : string
+        Repeat : int
+    }
+
+type BenchmarkAction =
+    | AnalyseFile of AnalyseFile
+    | BuildProject of BuildProject
 
 type BenchmarkInputs =
     {
@@ -68,6 +89,13 @@ let actionToDto =
                 Repeat = x.Repeat
             }
             |> BenchmarkActionDto.AnalyseFile
+        | BenchmarkAction.BuildProject x ->
+            {
+                BuildProjectDto.Args = x.Args
+                ProjectFileName = x.ProjectFileName
+                Repeat = x.Repeat
+            }
+            |> BenchmarkActionDto.BuildProject
     |> memoizeUsingRefComparison
 
 let inputsToDtos =
@@ -90,6 +118,13 @@ let private actionFromDto =
                 Repeat = x.Repeat
             }
             |> BenchmarkAction.AnalyseFile
+        | BenchmarkActionDto.BuildProject x ->
+            {
+                BuildProject.Args = x.Args
+                ProjectFileName = x.ProjectFileName
+                Repeat = x.Repeat
+            }
+            |> BenchmarkAction.BuildProject
     |> memoizeUsingRefComparison
 
 let private inputsFromDto =

--- a/Serialisation/Options.fs
+++ b/Serialisation/Options.fs
@@ -10,24 +10,25 @@ open FSharp.Compiler.CodeAnalysis
 
 let internal memoizeUsingRefComparison fn =
     let refComparer =
-        {
-            new IEqualityComparer<'a> with
-                member this.Equals(a, b) = obj.ReferenceEquals(a, b)
-                member this.GetHashCode(a) = RuntimeHelpers.GetHashCode(a)
+        { new IEqualityComparer<'a> with
+            member this.Equals (a, b) = obj.ReferenceEquals (a, b)
+            member this.GetHashCode (a) = RuntimeHelpers.GetHashCode (a)
         }
-    let cache = Dictionary<_,_>(refComparer)
+
+    let cache = Dictionary<_, _> (refComparer)
+
     fun x ->
         match cache.TryGetValue x with
         | true, v -> v
         | false, _ ->
             let v = fn x
-            cache.Add(x,v)
+            cache.Add (x, v)
             v
 
 [<CLIMutable>]
 type FSharpReferenceDto =
     {
-        OutputFile: string
+        OutputFile : string
         Options : FSharpProjectOptionsDto
     }
 
@@ -36,59 +37,63 @@ and [<CLIMutable>] FSharpProjectOptionsDto =
         ProjectFileName : string
         ProjectId : string option
         SourceFiles : List<string>
-        OtherOptions: List<string>
-        ReferencedProjects: List<FSharpReferenceDto>
+        OtherOptions : List<string>
+        ReferencedProjects : List<FSharpReferenceDto>
         IsIncompleteTypeCheckEnvironment : bool
         UseScriptResolutionRules : bool
         LoadTime : DateTime
-        Stamp: int64 option
+        Stamp : int64 option
     }
 
 let rec internal referenceToDto =
-    fun (rp : FSharpReferencedProject) -> 
+    fun (rp : FSharpReferencedProject) ->
         // Reflection is needed since DU cases are internal.
         // The alternative is to add an [<InternalsVisibleTo>] entry to the FCS project
-        let c, fields = FSharpValue.GetUnionFields(rp, typeof<FSharpReferencedProject>, true)
+        let c, fields =
+            FSharpValue.GetUnionFields (rp, typeof<FSharpReferencedProject>, true)
+
         match c.Name with
         | "FSharpReference" ->
             let outputFile = fields[0] :?> string
             let options = fields[1] :?> FSharpProjectOptions
             let fakeOptions = optionsToDto options
+
             {
                 FSharpReferenceDto.OutputFile = outputFile
                 FSharpReferenceDto.Options = fakeOptions
             }
-        | _ -> failwith $"Unsupported {nameof(FSharpReferencedProject)} DU case: {c.Name}. only 'FSharpReference' is supported by the serializer"
+        | _ ->
+            failwith
+                $"Unsupported {nameof (FSharpReferencedProject)} DU case: {c.Name}. only 'FSharpReference' is supported by the serializer"
     |> memoizeUsingRefComparison
 
 and internal optionsToDto =
     let mutable stamp = 1L
+
     let nextStamp () =
         stamp <- stamp + 1L
         stamp
+
     fun (o : FSharpProjectOptions) ->
         {
             ProjectFileName = o.ProjectFileName
             ProjectId = o.ProjectId
             SourceFiles = o.SourceFiles |> List
             OtherOptions = o.OtherOptions |> List
-            ReferencedProjects =
-                o.ReferencedProjects
-                |> Array.map referenceToDto
-                |> List
+            ReferencedProjects = o.ReferencedProjects |> Array.map referenceToDto |> List
             IsIncompleteTypeCheckEnvironment = o.IsIncompleteTypeCheckEnvironment
             UseScriptResolutionRules = o.UseScriptResolutionRules
             LoadTime = o.LoadTime
             // We always override the Stamp provided.
             // This is to avoid FCS spending a huge amount of time comparing projects when all Stamps are None
-            Stamp = nextStamp() |> Some 
+            Stamp = nextStamp () |> Some
         }
     |> memoizeUsingRefComparison
-    
+
 let rec private fakeRP =
     fun (rp : FSharpReferenceDto) ->
         let back = optionsFromDto rp.Options
-        FSharpReferencedProject.CreateFSharp(rp.OutputFile, back)
+        FSharpReferencedProject.CreateFSharp (rp.OutputFile, back)
     |> memoizeUsingRefComparison
 
 and internal optionsFromDto =
@@ -96,11 +101,9 @@ and internal optionsFromDto =
         {
             ProjectFileName = o.ProjectFileName
             ProjectId = o.ProjectId
-            SourceFiles = o.SourceFiles.ToArray()
-            OtherOptions = o.OtherOptions.ToArray()
-            ReferencedProjects =
-                o.ReferencedProjects.ToArray()
-                |> Array.map fakeRP            
+            SourceFiles = o.SourceFiles.ToArray ()
+            OtherOptions = o.OtherOptions.ToArray ()
+            ReferencedProjects = o.ReferencedProjects.ToArray () |> Array.map fakeRP
             IsIncompleteTypeCheckEnvironment = o.IsIncompleteTypeCheckEnvironment
             UseScriptResolutionRules = o.UseScriptResolutionRules
             LoadTime = o.LoadTime

--- a/Utils.fs
+++ b/Utils.fs
@@ -4,9 +4,9 @@ module FCSBenchmark.Generator.Utils
 open System.Collections.Generic
 open System.Diagnostics
 open Serilog.Events
-    
+
 let runProcess name args workingDir (envVariables : (string * string) list) (outputLogLevel : LogEventLevel) =
-    let info = ProcessStartInfo()
+    let info = ProcessStartInfo ()
     info.WindowStyle <- ProcessWindowStyle.Hidden
     info.Arguments <- args
     info.FileName <- name
@@ -15,30 +15,30 @@ let runProcess name args workingDir (envVariables : (string * string) list) (out
     info.RedirectStandardError <- true
     info.RedirectStandardOutput <- true
     info.CreateNoWindow <- true
-    
-    envVariables
-    |> List.iter (fun (k, v) -> info.EnvironmentVariables[k] <- v)
-    
-    log.Verbose("Running '{name} {args}' in '{workingDir}'", name, args, workingDir)
-    let p = new Process(StartInfo = info)
+
+    envVariables |> List.iter (fun (k, v) -> info.EnvironmentVariables[ k ] <- v)
+
+    log.Verbose ("Running '{name} {args}' in '{workingDir}'", name, args, workingDir)
+    let p = new Process (StartInfo = info)
     p.EnableRaisingEvents <- true
-    let output = List<string>()
-    p.OutputDataReceived.Add(fun args ->
-        log.Write(outputLogLevel, args.Data)
-        output.Add(args.Data)
+    let output = List<string> ()
+
+    p.OutputDataReceived.Add (fun args ->
+        log.Write (outputLogLevel, args.Data)
+        output.Add (args.Data)
     )
-    p.ErrorDataReceived.Add(fun args -> log.Error(args.Data))
-    p.Start() |> ignore
-    p.BeginErrorReadLine()
-    p.BeginOutputReadLine()
-    p.WaitForExit()
-    
+
+    p.ErrorDataReceived.Add (fun args -> log.Error (args.Data))
+    p.Start () |> ignore
+    p.BeginErrorReadLine ()
+    p.BeginOutputReadLine ()
+    p.WaitForExit ()
+
     if p.ExitCode <> 0 then
-        if log.IsEnabled(outputLogLevel) then
-            log.Error("Process '{name} {args}' failed - check full process output above.", name, args)
+        if log.IsEnabled (outputLogLevel) then
+            log.Error ("Process '{name} {args}' failed - check full process output above.", name, args)
         else
-            log.Error($"Process '{name} {args}' failed - printing its full output.", name, args)
-            output
-            |> Seq.iter log.Error
-                
+            log.Error ($"Process '{name} {args}' failed - printing its full output.", name, args)
+            output |> Seq.iter log.Error
+
         failwith $"Process {name} {args} failed - check full process output above."


### PR DESCRIPTION
Ignore the first commits, I would rebase afterwards.

In 034123a9143b7f690497c793751ce375a32c46da I tried to add a way to run `checker.Compile`.

This currently doesn't really work.
`Compile` expects all the DLLs to be present. I tried building the project via an external process first, but that didn't end well (See https://github.com/dotnet/sdk/issues/9298).

And when the projects were all built before running the Generator, the FSharpProjectOption are as good as empty 😔. I'm not sure why that is, although I assume the attempt to build projects mixes up things.

In short, not sure if you really want this one 😅 